### PR TITLE
gizmo: Add exit code to ProgramRTC.sh

### DIFF
--- a/Production/ProgramRTC.sh
+++ b/Production/ProgramRTC.sh
@@ -84,3 +84,5 @@ done
 
 # Flashes the B bank to indicate completed programming
 blink_b_bank
+
+exit 0


### PR DESCRIPTION
Right now there is no exit code, so Factory doesn't know if the script completed successfully. We need to add this so that way we can move another step forward when programming completes. 


